### PR TITLE
add tooltip to askForChoice's option

### DIFF
--- a/src/ui/roomscene.cpp
+++ b/src/ui/roomscene.cpp
@@ -1417,6 +1417,9 @@ void RoomScene::chooseOption(const QString &skillName, const QStringList &option
         button->setObjectName(option);
         button->setText(translated);
 
+        QString tooltip = Sanguosha->translate(QString(":%1").arg(option));
+        if (tooltip != QString(":%1").arg(option)) button->setToolTip(tooltip);
+
         connect(button, SIGNAL(clicked()), dialog, SLOT(accept()));
         connect(button, SIGNAL(clicked()), ClientInstance, SLOT(onPlayerMakeChoice()));
 


### PR DESCRIPTION
chooseOption 的时候，鼠标移到每个选项上可以显示帮助信息。

![chooseoption](https://qsgsext.googlecode.com/svn/wiki/chooseoption.jpg)
